### PR TITLE
Made bourbon whine and bitch less

### DIFF
--- a/client/css/neat/grid/_box-sizing.scss
+++ b/client/css/neat/grid/_box-sizing.scss
@@ -2,14 +2,14 @@
 
 @if $border-box-sizing == true {
   html { // http://bit.ly/1qk2tVR
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   * {
     &,
     &:before,
     &:after {
-      @include box-sizing(inherit);
+      box-sizing: inherit;
     }
   }
 }


### PR DESCRIPTION
The box-sizing mixin is deprecated because vendor prefixes are going away, so I just switched it to use the unprefixed raw CSS instead of the mixin.
